### PR TITLE
Add dark theme support and watchOS PWS debug label

### DIFF
--- a/watch Extension/InterfaceController.swift
+++ b/watch Extension/InterfaceController.swift
@@ -19,6 +19,7 @@ class InterfaceController: WKInterfaceController, @preconcurrency URLSessionDele
     @IBOutlet var weatherTable: WKInterfaceTable!
     @IBOutlet var selectCityButton: WKInterfaceButton!
     @IBOutlet var lastRefreshLabel: WKInterfaceLabel!
+    @IBOutlet var pwsDebugLabel: WKInterfaceLabel!
     @IBOutlet var locatingImage: WKInterfaceImage!
     @IBOutlet var locationErrorLabel: WKInterfaceLabel!
     
@@ -180,6 +181,17 @@ class InterfaceController: WKInterfaceController, @preconcurrency URLSessionDele
 
         #if ENABLE_PWS
         let city = watchDelegate.wrapper.city
+        let stations = PreferenceHelper.getPWSStations()
+        let hasCredentials = PreferenceHelper.hasPWSCredentials()
+        if hasCredentials && !stations.isEmpty {
+            let stationId = stations.first?.stationId ?? "no id"
+            pwsDebugLabel.setText("PWS: \(stationId)")
+        } else if hasCredentials {
+            pwsDebugLabel.setText("PWS: no id")
+        } else {
+            pwsDebugLabel.setText("PWS: no credentials")
+        }
+
         DispatchQueue.global(qos: .userInitiated).async {
             let pws = Self.fetchPWSSync(for: city)
             if let pwsTemp = pws.temperature {
@@ -192,6 +204,8 @@ class InterfaceController: WKInterfaceController, @preconcurrency URLSessionDele
                 }
             }
         }
+        #else
+        pwsDebugLabel.setText("PWS disabled")
         #endif
     }
     

--- a/watch Extension/WCSessionDelegateHandler.swift
+++ b/watch Extension/WCSessionDelegateHandler.swift
@@ -14,6 +14,16 @@ class WCSessionDelegateHandler: NSObject, WCSessionDelegate {
         #if DEBUG
             print("WCSession activation: \(activationState.rawValue)")
         #endif
+
+        if activationState == .activated {
+            let existingContext = session.receivedApplicationContext
+            if !existingContext.isEmpty {
+                #if DEBUG
+                    print("Processing existing applicationContext on activation")
+                #endif
+                applyApplicationContext(existingContext)
+            }
+        }
     }
 
     func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String : Any]) {
@@ -21,6 +31,10 @@ class WCSessionDelegateHandler: NSObject, WCSessionDelegate {
             print("Received applicationContext from iPhone")
         #endif
 
+        applyApplicationContext(applicationContext)
+    }
+
+    private func applyApplicationContext(_ applicationContext: [String : Any]) {
         let defaults = UserDefaults(suiteName: Global.SettingGroup)!
 
         if let data = applicationContext[Global.selectedCityKey] as? Data {

--- a/watch/Base.lproj/Interface.storyboard
+++ b/watch/Base.lproj/Interface.storyboard
@@ -105,6 +105,10 @@
                         <label width="1" alignment="left" hidden="YES" text="Last refresh" numberOfLines="2" id="6me-SD-2jn">
                             <fontDescription key="font" style="UICTFontTextStyleFootnote"/>
                         </label>
+                        <label width="1" alignment="left" text="" numberOfLines="1" id="pws-Db-Lbl">
+                            <fontDescription key="font" style="UICTFontTextStyleCaption2"/>
+                            <color key="textColor" red="1" green="1" blue="1" alpha="0.5" colorSpace="custom" customColorSpace="sRGB"/>
+                        </label>
                     </items>
                     <menu key="menu" id="iB8-eH-vfl"/>
                     <connections>
@@ -114,6 +118,7 @@
                         <outlet property="locationErrorLabel" destination="hNI-1L-1Pp" id="COZ-4t-y70"/>
                         <outlet property="selectCityButton" destination="ai4-HS-V5P" id="899-k6-Olf"/>
                         <outlet property="stationImage" destination="6bM-t3-3Q8" id="8lR-2P-Cjz"/>
+                        <outlet property="pwsDebugLabel" destination="pws-Db-Lbl" id="pws-Db-Con"/>
                         <outlet property="weatherTable" destination="TYl-Sm-JJI" id="ulS-d7-dXp"/>
                     </connections>
                 </controller>

--- a/weatherlr/SettingsViewController.swift
+++ b/weatherlr/SettingsViewController.swift
@@ -34,6 +34,9 @@ class SettingsViewController: UITableViewController, @preconcurrency ModalDelega
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        overrideUserInterfaceStyle = .unspecified
+        tableView.backgroundColor = .systemGroupedBackground
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -141,6 +144,7 @@ class SettingsViewController: UITableViewController, @preconcurrency ModalDelega
 
             let city = savedCities[indexPath.row]
             cell.cityLabel.text = CityHelper.cityName(city)
+            cell.cityLabel.textColor = .label
 
             if selectedCity != nil && city.id == selectedCity!.id {
                 cell.accessoryType = UITableViewCell.AccessoryType.checkmark
@@ -167,6 +171,8 @@ class SettingsViewController: UITableViewController, @preconcurrency ModalDelega
             let cell = tableView.dequeueReusableCell(withIdentifier: "langCell", for: indexPath) as! LangTableViewCell
 
             cell.accessoryType = UITableViewCell.AccessoryType.none
+
+            cell.langLabel.textColor = .label
 
             if indexPath.row == francaisRow {
                 cell.langLabel.text = "Français"
@@ -199,6 +205,7 @@ class SettingsViewController: UITableViewController, @preconcurrency ModalDelega
             let cell = tableView.dequeueReusableCell(withIdentifier: "dataProviderCell", for: indexPath) as! DataProviderTableViewCell
 
             cell.dataProviderLabel.text = "Provider".localized()
+            cell.dataProviderLabel.textColor = .label
             cell.backgroundColor = UIColor.clear
 
             return cell
@@ -367,6 +374,9 @@ class SettingsViewController: UITableViewController, @preconcurrency ModalDelega
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
+        if traitCollection.userInterfaceStyle == .dark {
+            return .lightContent
+        }
         return .default
     }
 

--- a/weatherlr/WeatherFramework/Weather/WeatherEnums.swift
+++ b/weatherlr/WeatherFramework/Weather/WeatherEnums.swift
@@ -173,6 +173,7 @@ public enum WeatherStatus : CaseIterable {
 public enum WeatherColor : Int {
     case rain = 0x1fbfff
     case defaultColor = 0x1f4f74
+    case nightColor = 0x0f2a3f
     case watchRing = 0x65DA7D
 }
 

--- a/weatherlr/WeatherFramework/WeatherHelper.swift
+++ b/weatherlr/WeatherFramework/WeatherHelper.swift
@@ -350,21 +350,20 @@ public class WeatherHelper {
             bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
         ) else { return baseImage }
 
-        context.draw(cgImage, in: CGRect(origin: .zero, size: size))
-
-        // Flip for text drawing (CoreGraphics origin is bottom-left)
+        // Flip the entire context so UIKit-style drawing works (origin top-left)
         context.translateBy(x: 0, y: size.height)
         context.scaleBy(x: 1.0, y: -1.0)
 
+        // Draw the base image (needs explicit flip since context is now flipped)
+        context.draw(cgImage, in: CGRect(origin: .zero, size: size))
+
+        // Draw text using NSAttributedString (works correctly in flipped context)
         let textFontAttributes: [NSAttributedString.Key: Any] = [
             .font: textFont,
             .foregroundColor: textColor
         ]
-        let attributedString = NSAttributedString(string: text, attributes: textFontAttributes)
-        let line = CTLineCreateWithAttributedString(attributedString)
-
-        context.textPosition = CGPoint(x: CGFloat(offsetLeft), y: size.height - CGFloat(offsetTop) - textFont.ascender)
-        CTLineDraw(line, context)
+        let rect = CGRect(x: CGFloat(offsetLeft), y: CGFloat(offsetTop), width: size.width, height: size.height)
+        text.draw(in: rect, withAttributes: textFontAttributes)
 
         guard let resultCGImage = context.makeImage() else { return baseImage }
         return UIImage(cgImage: resultCGImage)

--- a/weatherlr/WeatherViewController.swift
+++ b/weatherlr/WeatherViewController.swift
@@ -204,6 +204,11 @@ class WeatherViewController: UIViewController, UITableViewDelegate, UITableViewD
             weatherTable.bounds.size.width = maxWidth
         }
 
+        // Use darker background at night
+        let isNight = weatherInformationWrapper.weatherInformations.first?.night ?? false
+        let bgColor = isNight ? UIColor(weatherColor: .nightColor) : UIColor(weatherColor: .defaultColor)
+        view.backgroundColor = bgColor
+
         guard warningBarButton != nil, radarButton != nil else { return }
 
         let city = PreferenceHelper.getCityToUse()


### PR DESCRIPTION
## Changes

- **Dark Theme Support**: Added dark theme support to Settings screen and weather view with dynamic background colors
- **watchOS PWS Debug**: Added PWS debug label to watch app InterfaceController showing station credentials and ID status
- **Night Mode Background**: Implement darker background color for night weather conditions
- **Text Rendering Fix**: Refactored image text drawing in WeatherHelper to use UIKit-style drawing for better compatibility
- **Color Enum**: Added `nightColor` to WeatherColor enum (0x0f2a3f)
- **UI Polish**: Fixed text colors and status bar styling for dark mode in SettingsViewController