### PR TITLE
fix(tests): add APP_GROUP_ID to test bundle for UserDefaults access

### DIFF
--- a/weatherlrTests/Info.plist
+++ b/weatherlrTests/Info.plist
@@ -20,5 +20,7 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>APP_GROUP_ID</key>
+	<string>$(APP_GROUP_ID)</string>
 </dict>
 </plist>


### PR DESCRIPTION
Fixes test failure: PreferenceHelperTests/testSaveAndGetLanguageEnglish was failing because APP_GROUP_ID was not set in the test bundle's Info.plist, causing UserDefaults(suiteName:) to fail.