### PR TITLE
fix(watch): show PWS station name in header when temperature is from PWS (#15)

### DIFF
--- a/watch Extension/WCSessionDelegateHandler.swift
+++ b/watch Extension/WCSessionDelegateHandler.swift
@@ -57,14 +57,26 @@ class WCSessionDelegateHandler: NSObject, WCSessionDelegate {
         if let apiKey = applicationContext["pwsApiKey"] as? String {
             defaults.set(apiKey, forKey: "pwsApiKey")
         }
+        // The iPhone rebuilds the full context from its defaults on every sync, and writes
+        // the reading keys (temperature / station name / timestamp) as an atomic group. Mirror
+        // that here: when the context carries no reading, clear all three so a stale reading
+        // can't linger on the Watch after the iPhone has stopped reporting one.
         if let pwsTemp = applicationContext[Global.pwsTemperatureKey] as? Int {
             defaults.set(pwsTemp, forKey: Global.pwsTemperatureKey)
-        }
-        if let pwsStation = applicationContext[Global.pwsStationNameKey] as? String {
-            defaults.set(pwsStation, forKey: Global.pwsStationNameKey)
-        }
-        if let pwsUpdatedAt = applicationContext[Global.pwsTemperatureUpdatedAtKey] as? TimeInterval {
-            defaults.set(pwsUpdatedAt, forKey: Global.pwsTemperatureUpdatedAtKey)
+            if let pwsStation = applicationContext[Global.pwsStationNameKey] as? String {
+                defaults.set(pwsStation, forKey: Global.pwsStationNameKey)
+            } else {
+                defaults.removeObject(forKey: Global.pwsStationNameKey)
+            }
+            if let pwsUpdatedAt = applicationContext[Global.pwsTemperatureUpdatedAtKey] as? TimeInterval {
+                defaults.set(pwsUpdatedAt, forKey: Global.pwsTemperatureUpdatedAtKey)
+            } else {
+                defaults.removeObject(forKey: Global.pwsTemperatureUpdatedAtKey)
+            }
+        } else {
+            defaults.removeObject(forKey: Global.pwsTemperatureKey)
+            defaults.removeObject(forKey: Global.pwsStationNameKey)
+            defaults.removeObject(forKey: Global.pwsTemperatureUpdatedAtKey)
         }
         #endif
 

--- a/watch Extension/WatchWeatherModel.swift
+++ b/watch Extension/WatchWeatherModel.swift
@@ -215,10 +215,13 @@ final class WatchWeatherModel {
         var closestName: String?
         var closestDistance: CLLocationDistance = .greatestFiniteMagnitude
 
+        // No distance cap: the user explicitly configured these stations, so when we already
+        // have a PWS reading we want to name its station regardless of how far it sits from the
+        // selected Environment Canada city. The 50 km filter belongs to the station-selection
+        // path (findClosestStation), not to this display-name lookup.
         for station in stations {
             let stationLocation = CLLocation(latitude: station.latitude, longitude: station.longitude)
             let distance = cityLocation.distance(from: stationLocation)
-            guard distance < 50_000 else { continue }
             if distance < closestDistance {
                 closestDistance = distance
                 closestName = station.name
@@ -230,10 +233,13 @@ final class WatchWeatherModel {
 
     nonisolated static func syncedPWSData() -> (temperature: Int?, stationName: String?, updatedAt: Date?) {
         let defaults = UserDefaults(suiteName: Global.SettingGroup)!
-        let stationName = defaults.string(forKey: Global.pwsStationNameKey)
-        guard stationName != nil, defaults.object(forKey: Global.pwsTemperatureKey) != nil else {
+        // The temperature is the source of truth: if it is present, a PWS reading is in
+        // play. The station name is best-effort — it may be missing if the sync delivered
+        // temperature first, so don't drop the temperature just because the name is absent.
+        guard defaults.object(forKey: Global.pwsTemperatureKey) != nil else {
             return (nil, nil, nil)
         }
+        let stationName = defaults.string(forKey: Global.pwsStationNameKey)
         let updatedAt: Date?
         if defaults.object(forKey: Global.pwsTemperatureUpdatedAtKey) != nil {
             updatedAt = Date(timeIntervalSince1970: defaults.double(forKey: Global.pwsTemperatureUpdatedAtKey))

--- a/watch Extension/WeatherContentView.swift
+++ b/watch Extension/WeatherContentView.swift
@@ -99,7 +99,10 @@ struct WeatherContentView: View {
                 .lineLimit(1)
 
             #if ENABLE_PWS
-            if model.pwsStationName != nil {
+            // Key the sensor icon off the temperature, not the name: whenever a PWS reading
+            // is substituted into the Current row, the header must signal it — even if the
+            // station name pipeline failed to deliver a name.
+            if model.pwsTemperature != nil {
                 Image(systemName: "sensor.fill")
                     .font(.system(size: 10, weight: .medium))
                     .foregroundColor(.white.opacity(0.7))
@@ -146,8 +149,14 @@ struct WeatherContentView: View {
         }
 
         #if ENABLE_PWS
-        if let stationName = model.pwsStationName {
+        if let stationName = model.pwsStationName, !stationName.isEmpty {
             return stationName
+        }
+        // A reading is from the PWS but we couldn't resolve its station name. Don't fall back
+        // to the city name — that would mislead the user into reading the PWS number as the
+        // Environment Canada value for the city. Show a generic PWS label instead.
+        if model.pwsTemperature != nil {
+            return "Personal weather station".localized()
         }
         #endif
 

--- a/weatherlr.xcodeproj/project.pbxproj
+++ b/weatherlr.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		6EFA11CA0000000000000010 /* WeatherInformationWrapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFA11CA0000000000000005 /* WeatherInformationWrapperTests.swift */; };
 		6EFA11CA0000000000000011 /* WeatherEnumsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFA11CA0000000000000006 /* WeatherEnumsTests.swift */; };
 		6EFA11CA0000000000000012 /* PreferenceHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFA11CA0000000000000007 /* PreferenceHelperTests.swift */; };
+		6EFA11CA0000000000000098 /* PWSServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFA11CA0000000000000097 /* PWSServiceTests.swift */; };
 		6EFA11CA0000000000000013 /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFA11CA0000000000000008 /* StringExtensionTests.swift */; };
 		6EFA11CA0000000000000014 /* UrlHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFA11CA0000000000000009 /* UrlHelperTests.swift */; };
 		6EFA11CA0000000000000015 /* AlertInformationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFA11CA000000000000000A /* AlertInformationTests.swift */; };
@@ -392,6 +393,7 @@
 		6EFA11CA0000000000000005 /* WeatherInformationWrapperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeatherInformationWrapperTests.swift; sourceTree = "<group>"; };
 		6EFA11CA0000000000000006 /* WeatherEnumsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WeatherEnumsTests.swift; sourceTree = "<group>"; };
 		6EFA11CA0000000000000007 /* PreferenceHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferenceHelperTests.swift; sourceTree = "<group>"; };
+		6EFA11CA0000000000000097 /* PWSServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PWSServiceTests.swift; sourceTree = "<group>"; };
 		6EFA11CA0000000000000008 /* StringExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
 		6EFA11CA0000000000000009 /* UrlHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UrlHelperTests.swift; sourceTree = "<group>"; };
 		6EFA11CA000000000000000A /* AlertInformationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertInformationTests.swift; sourceTree = "<group>"; };
@@ -604,6 +606,7 @@
 				6EFA11CA0000000000000005 /* WeatherInformationWrapperTests.swift */,
 				6EFA11CA0000000000000006 /* WeatherEnumsTests.swift */,
 				6EFA11CA0000000000000007 /* PreferenceHelperTests.swift */,
+				6EFA11CA0000000000000097 /* PWSServiceTests.swift */,
 				6EFA11CA0000000000000008 /* StringExtensionTests.swift */,
 				6EFA11CA0000000000000009 /* UrlHelperTests.swift */,
 				6EFA11CA000000000000000A /* AlertInformationTests.swift */,
@@ -1158,6 +1161,7 @@
 				6EFA11CA0000000000000010 /* WeatherInformationWrapperTests.swift in Sources */,
 				6EFA11CA0000000000000011 /* WeatherEnumsTests.swift in Sources */,
 				6EFA11CA0000000000000012 /* PreferenceHelperTests.swift in Sources */,
+				6EFA11CA0000000000000098 /* PWSServiceTests.swift in Sources */,
 				6EFA11CA0000000000000013 /* StringExtensionTests.swift in Sources */,
 				6EFA11CA0000000000000014 /* UrlHelperTests.swift in Sources */,
 				6EFA11CA0000000000000015 /* AlertInformationTests.swift in Sources */,
@@ -1839,6 +1843,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 111;
 				INFOPLIST_FILE = weatherlrTests/Info.plist;
+				OTHER_SWIFT_FLAGS = "-DDEBUG -DENABLE_PWS -DENABLE_PRECIPITATION";
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/weatherlr.xcodeproj/xcshareddata/xcschemes/PréviCA+.xcscheme
+++ b/weatherlr.xcodeproj/xcshareddata/xcschemes/PréviCA+.xcscheme
@@ -29,6 +29,18 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6E29053B1CB2D5550040EB8B"
+               BuildableName = "weatherlrTests.xctest"
+               BlueprintName = "weatherlrTests"
+               ReferencedContainer = "container:weatherlr.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "DebugInternal"

--- a/weatherlr/WeatherFramework/PWS/PWSService.swift
+++ b/weatherlr/WeatherFramework/PWS/PWSService.swift
@@ -60,11 +60,12 @@ class PWSService {
         var closestName: String?
         var closestDistance: CLLocationDistance = .greatestFiniteMagnitude
 
+        // No distance cap here: this is the display-name lookup for a reading we already
+        // have. The 50 km filter that decides which station to actually fetch from lives in
+        // findClosestStation below.
         for station in stations {
             let stationLocation = CLLocation(latitude: station.latitude, longitude: station.longitude)
             let distance = cityLocation.distance(from: stationLocation)
-
-            guard distance < 50_000 else { continue }
 
             if distance < closestDistance {
                 closestDistance = distance

--- a/weatherlr/en.lproj/Localizable.strings
+++ b/weatherlr/en.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "More details" = "More details";
 "Radar" = "Radar";
 "Currently" = "Currently";
+"Personal weather station" = "Weather station";
 "Minimum" = "Minimum";
 "Maximum" = "Maximum";
 "Min" = "Min";

--- a/weatherlr/fr.lproj/Localizable.strings
+++ b/weatherlr/fr.lproj/Localizable.strings
@@ -25,6 +25,7 @@
 "More details" = "Plus de détail";
 "Radar" = "Radar";
 "Currently" = "Il fait";
+"Personal weather station" = "Station météo";
 "Minimum" = "Minimum";
 "Maximum" = "Maximum";
 "Min" = "Min";

--- a/weatherlrTests/PWSServiceTests.swift
+++ b/weatherlrTests/PWSServiceTests.swift
@@ -1,0 +1,66 @@
+//
+//  PWSServiceTests.swift
+//  weatherlrTests
+//
+//  Covers issue #15: the PWS station-name lookup must return a configured
+//  station's name regardless of its distance from the selected city, so the
+//  watchOS header can name the station behind a substituted PWS temperature.
+//
+//  These tests rely on APP_GROUP_ID being set in the test bundle Info.plist so
+//  that UserDefaults(suiteName: Global.SettingGroup) returns a real, isolated
+//  defaults instance.
+//
+
+#if ENABLE_PWS
+import XCTest
+@testable import weatherlr
+
+@MainActor
+final class PWSServiceTests: XCTestCase {
+
+    nonisolated private func resetDefaults() {
+        let defaults = UserDefaults(suiteName: Global.SettingGroup)!
+        defaults.removePersistentDomain(forName: Global.SettingGroup)
+        // hasPWSCredentials() needs a non-empty API key (synced-key fallback used when
+        // no Secrets.plist key is present).
+        defaults.set("test-api-key", forKey: "pwsApiKey")
+    }
+
+    override func setUp() {
+        super.setUp()
+        resetDefaults()
+    }
+
+    override func tearDown() {
+        UserDefaults(suiteName: Global.SettingGroup)!.removePersistentDomain(forName: Global.SettingGroup)
+        super.tearDown()
+    }
+
+    private func montreal() -> City {
+        return City(id: "1", frenchName: "Montréal", englishName: "Montreal",
+                    province: "QC", radarId: "WMN", latitude: "45.5", longitude: "-73.6")
+    }
+
+    func testClosestStationNameReturnsNilWhenNoStations() {
+        PreferenceHelper.savePWSStations([])
+        XCTAssertNil(PWSService.shared.closestStationName(to: montreal()))
+    }
+
+    func testClosestStationNameReturnsNearestStation() {
+        PreferenceHelper.savePWSStations([
+            PWSStation(stationId: "S1", name: "Near", latitude: 45.51, longitude: -73.61),
+            PWSStation(stationId: "S2", name: "Far", latitude: 46.8, longitude: -71.2)
+        ])
+        XCTAssertEqual("Near", PWSService.shared.closestStationName(to: montreal()))
+    }
+
+    func testClosestStationNameReturnsStationBeyond50km() {
+        // The only configured station is well beyond the old 50 km cap (Montreal -> Quebec
+        // City is ~230 km). The user explicitly configured it, so its name must still surface.
+        PreferenceHelper.savePWSStations([
+            PWSStation(stationId: "S2", name: "Quebec City", latitude: 46.81, longitude: -71.21)
+        ])
+        XCTAssertEqual("Quebec City", PWSService.shared.closestStationName(to: montreal()))
+    }
+}
+#endif


### PR DESCRIPTION
- Sync temperature and station name atomically; clear all PWS keys together when no reading
- Remove 50 km distance cap from `closestStationName` lookup for display name
- Key sensor icon off `pwsTemperature` (not just `pwsStationName`) so icon appears whenever a PWS reading is in play
- Fall back to "Personal weather station" label when temperature exists but station name is missing
- Add `PWSServiceTests` covering name lookup independent of distance