### PR TITLE
fix(watch-widget): add widgetURL to enable complication tap handling #18

### DIFF
--- a/watch Extension/WatchApp.swift
+++ b/watch Extension/WatchApp.swift
@@ -15,6 +15,12 @@ struct WatchApp: App {
     var body: some Scene {
         WindowGroup {
             WeatherContentView()
+                .onOpenURL { url in
+                    // Tapping the complication launches the app via the
+                    // "previca://open" URL. No parameters are parsed yet;
+                    // this handler is the hook for future deep-linking.
+                    _ = url
+                }
         }
     }
 }

--- a/watch Widget/watchWidget.swift
+++ b/watch Widget/watchWidget.swift
@@ -351,8 +351,10 @@ struct WatchWeatherWidget: Widget {
             if #available(watchOSApplicationExtension 10.0, *) {
                 WatchWeatherWidgetEntryView(entry: entry)
                     .containerBackground(Color(red: 31.0/255.0, green: 79.0/255.0, blue: 116.0/255.0), for: .widget)
+                    .widgetURL(URL(string: "previca://open"))
             } else {
                 WatchWeatherWidgetEntryView(entry: entry)
+                    .widgetURL(URL(string: "previca://open"))
             }
         }
         .configurationDisplayName("PréviCA")

--- a/watch/Info.plist
+++ b/watch/Info.plist
@@ -22,6 +22,17 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>245</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>previca</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
- Add widgetURL("previca://open") to WatchWeatherWidget entry view
- Register previca:// URL scheme in watch app Info.plist
- Add onOpenURL handler in WatchApp for future deep-linking