### PR TITLE
fix(radar): validate PNG tiles before caching to prevent partial radar (#23)

### DIFF
--- a/weatherlr.xcodeproj/project.pbxproj
+++ b/weatherlr.xcodeproj/project.pbxproj
@@ -101,6 +101,7 @@
 		6EFA11CA0000000000000015 /* AlertInformationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFA11CA000000000000000A /* AlertInformationTests.swift */; };
 		6EFA11CA0000000000000016 /* HourlyForecastInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFA11CA000000000000000B /* HourlyForecastInfoTests.swift */; };
 		6EFA11CA0000000000000018 /* MiscHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFA11CA0000000000000017 /* MiscHelperTests.swift */; };
+		6EFA11CA0000000000000117 /* WMSTileOverlayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFA11CA0000000000000118 /* WMSTileOverlayTests.swift */; };
 		6EFA11CA0000000000000020 /* ViewControllerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFA11CA0000000000000019 /* ViewControllerUnitTests.swift */; };
 		6EFA11CA00000000DEADBEE2 /* UITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EFA11CA00000000DEADBEE1 /* UITestSupport.swift */; };
 		6EFA11CA00000000DEADBEE4 /* ui_test_fixture.json in Resources */ = {isa = PBXBuildFile; fileRef = 6EFA11CA00000000DEADBEE3 /* ui_test_fixture.json */; };
@@ -399,6 +400,7 @@
 		6EFA11CA000000000000000A /* AlertInformationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AlertInformationTests.swift; sourceTree = "<group>"; };
 		6EFA11CA000000000000000B /* HourlyForecastInfoTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HourlyForecastInfoTests.swift; sourceTree = "<group>"; };
 		6EFA11CA0000000000000017 /* MiscHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MiscHelperTests.swift; sourceTree = "<group>"; };
+		6EFA11CA0000000000000118 /* WMSTileOverlayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WMSTileOverlayTests.swift; sourceTree = "<group>"; };
 		6EFA11CA0000000000000019 /* ViewControllerUnitTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewControllerUnitTests.swift; sourceTree = "<group>"; };
 		6EFA11CA00000000DEADBEE1 /* UITestSupport.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITestSupport.swift; sourceTree = "<group>"; };
 		6EFA11CA00000000DEADBEE3 /* ui_test_fixture.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = ui_test_fixture.json; sourceTree = "<group>"; };
@@ -612,6 +614,7 @@
 				6EFA11CA000000000000000A /* AlertInformationTests.swift */,
 				6EFA11CA000000000000000B /* HourlyForecastInfoTests.swift */,
 				6EFA11CA0000000000000017 /* MiscHelperTests.swift */,
+				6EFA11CA0000000000000118 /* WMSTileOverlayTests.swift */,
 				6EFA11CA0000000000000019 /* ViewControllerUnitTests.swift */,
 			);
 			path = weatherlrTests;
@@ -1167,6 +1170,7 @@
 				6EFA11CA0000000000000015 /* AlertInformationTests.swift in Sources */,
 				6EFA11CA0000000000000016 /* HourlyForecastInfoTests.swift in Sources */,
 				6EFA11CA0000000000000018 /* MiscHelperTests.swift in Sources */,
+				6EFA11CA0000000000000117 /* WMSTileOverlayTests.swift in Sources */,
 				6EFA11CA0000000000000020 /* ViewControllerUnitTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/weatherlr/RadarViewController.swift
+++ b/weatherlr/RadarViewController.swift
@@ -239,6 +239,11 @@ class RadarViewController: UIViewController, MKMapViewDelegate {
             let remaining = Array(0..<steps.count).filter { $0 != self.currentFrameIndex }
             self.prefetchFramesSequentially(remaining, tilePaths: tilePaths)
         }
+
+        // The first frame renders before the prefetch burst finishes, so any tile
+        // that came back rate-limited won't recover on its own (no region change to
+        // nudge MapKit). Re-request the current frame's tiles once it has settled.
+        scheduleInitialOverlayRefresh()
     }
 
     private func addOverlayToMap(at index: Int) {
@@ -279,9 +284,14 @@ class RadarViewController: UIViewController, MKMapViewDelegate {
         for url in urls {
             group.enter()
             let request = URLRequest(url: url, cachePolicy: .returnCacheDataElseLoad, timeoutInterval: 30)
-            session.dataTask(with: request) { data, _, _ in
-                if let data = data {
-                    TileDataCache.shared.set(data, for: url)
+            session.dataTask(with: request) { data, response, error in
+                if let validData = WMSTileOverlay.validate(data, response) {
+                    TileDataCache.shared.set(validData, for: url)
+                } else {
+                    // Same guard as WMSTileOverlay.loadTile: never cache a non-PNG body,
+                    // and evict any poisoned disk entry so the tile is re-fetched later.
+                    session.configuration.urlCache?.removeCachedResponse(for: request)
+                    WMSTileOverlay.logRejectedTile(data: data, response: response, error: error)
                 }
                 group.leave()
             }.resume()
@@ -454,7 +464,37 @@ class RadarViewController: UIViewController, MKMapViewDelegate {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05, execute: work)
     }
 
+    // MARK: - Overlay Recovery
+
+    /// Forces the current frame's renderer to drop any partial state and
+    /// re-request its visible tiles. A failed `loadTile` (e.g. a GeoMet 429)
+    /// otherwise leaves a permanent hole because MapKit marks the slot drawn and
+    /// never retries on its own.
+    private func reloadCurrentFrameRenderer(reason: String) {
+        guard currentFrameIndex >= 0, currentFrameIndex < tileOverlays.count else { return }
+        let id = ObjectIdentifier(tileOverlays[currentFrameIndex])
+        guard let renderer = rendererMap[id] else { return }
+        print("[Radar] \(reason) — reloading current frame renderer")
+        renderer.reloadData()
+    }
+
+    /// One-shot recovery for the very first frame, which has no region change
+    /// between `setRegion(animated: false)` and its first render to trigger
+    /// `regionDidChangeAnimated`. 2s is enough for the initial prefetch wave to
+    /// finish so tiles rejected by validation are re-requested.
+    private func scheduleInitialOverlayRefresh() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            self?.reloadCurrentFrameRenderer(reason: "initial refresh")
+        }
+    }
+
     // MARK: - MKMapViewDelegate
+
+    func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
+        // After the map settles (initial setRegion, didUpdateLocations, or a user
+        // gesture), re-request visible tiles so partial overlays fill in.
+        reloadCurrentFrameRenderer(reason: "region settled")
+    }
 
     func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {
         if let tileOverlay = overlay as? WMSTileOverlay {

--- a/weatherlr/WMSTileOverlay.swift
+++ b/weatherlr/WMSTileOverlay.swift
@@ -11,7 +11,9 @@ import MapKit
 extension URLCache {
     static let radarTileCache: URLCache = {
         let cachesDir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
-        let directory = cachesDir?.appendingPathComponent("RadarTiles", isDirectory: true)
+        // "V2": bumped from "RadarTiles" to abandon any poisoned tiles cached by
+        // earlier builds that stored non-PNG responses (see WMSTileOverlay.validate).
+        let directory = cachesDir?.appendingPathComponent("RadarTilesV2", isDirectory: true)
         return URLCache(memoryCapacity: 50 * 1024 * 1024,
                         diskCapacity: 200 * 1024 * 1024,
                         directory: directory)
@@ -76,11 +78,19 @@ class WMSTileOverlay: MKTileOverlay {
         }
 
         let request = URLRequest(url: tileURL, cachePolicy: .returnCacheDataElseLoad, timeoutInterval: 30)
-        WMSTileOverlay.sharedTileSession.dataTask(with: request) { data, _, error in
-            if let data = data {
-                TileDataCache.shared.set(data, for: tileURL)
+        WMSTileOverlay.sharedTileSession.dataTask(with: request) { data, response, error in
+            if let validData = WMSTileOverlay.validate(data, response) {
+                TileDataCache.shared.set(validData, for: tileURL)
+                result(validData, nil)
+            } else {
+                // Don't cache garbage (429s, error pages, truncated bodies). Evict any
+                // poisoned disk entry and report a failure so MKTileOverlayRenderer
+                // re-requests this tile on the next reloadData() — see
+                // RadarViewController.mapView(_:regionDidChangeAnimated:).
+                WMSTileOverlay.sharedTileSession.configuration.urlCache?.removeCachedResponse(for: request)
+                WMSTileOverlay.logRejectedTile(data: data, response: response, error: error)
+                result(nil, error)
             }
-            result(data, error)
         }.resume()
     }
 
@@ -91,5 +101,35 @@ class WMSTileOverlay: MKTileOverlay {
         let maxY = WMSTileOverlay.originShift - Double(y) * tileSize
         let minY = maxY - tileSize
         return (minX, minY, maxX, maxY)
+    }
+}
+
+// MARK: - Tile Validation
+
+extension WMSTileOverlay {
+    /// PNG file signature (first 8 bytes): 89 50 4E 47 0D 0A 1A 0A.
+    private static let pngSignature: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+
+    /// Returns `data` only when the response looks like a real PNG tile worth
+    /// caching: an HTTP 2xx response whose body begins with the PNG signature.
+    /// Rejects rate-limit / error responses and HTML error pages, which would
+    /// otherwise be cached and rendered as transparent (empty) tiles.
+    static func validate(_ data: Data?, _ response: URLResponse?) -> Data? {
+        guard let data, data.count >= pngSignature.count,
+              let http = response as? HTTPURLResponse,
+              (200..<300).contains(http.statusCode) else {
+            return nil
+        }
+        for (offset, byte) in pngSignature.enumerated() where data[data.startIndex + offset] != byte {
+            return nil
+        }
+        return data
+    }
+
+    /// Logs a tile that failed validation so partial-load investigations can be
+    /// confirmed from device logs (matches the existing `[Radar]` log prefix).
+    static func logRejectedTile(data: Data?, response: URLResponse?, error: Error?) {
+        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
+        print("[Radar] rejected tile — status=\(status) bytes=\(data?.count ?? 0) error=\(error?.localizedDescription ?? "none")")
     }
 }

--- a/weatherlrTests/WMSTileOverlayTests.swift
+++ b/weatherlrTests/WMSTileOverlayTests.swift
@@ -1,0 +1,59 @@
+//
+//  WMSTileOverlayTests.swift
+//  weatherlrTests
+//
+//  Covers WMSTileOverlay.validate, which guards the radar tile caches against
+//  rate-limit / error responses that would otherwise render as empty tiles
+//  (see issue #23).
+//
+
+import XCTest
+@testable import weatherlr
+
+final class WMSTileOverlayTests: XCTestCase {
+
+    private let url = URL(string: "https://geo.weather.gc.ca/geomet")!
+
+    /// First 8 bytes of any PNG file, plus a couple of payload bytes.
+    private var pngData: Data {
+        Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x01])
+    }
+
+    private func httpResponse(_ statusCode: Int) -> HTTPURLResponse {
+        HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: "HTTP/1.1", headerFields: nil)!
+    }
+
+    func testValidPngWith200IsAccepted() {
+        XCTAssertEqual(WMSTileOverlay.validate(pngData, httpResponse(200)), pngData)
+    }
+
+    func testValidPngWithRateLimitIsRejected() {
+        XCTAssertNil(WMSTileOverlay.validate(pngData, httpResponse(429)))
+    }
+
+    func testValidPngWithServerErrorIsRejected() {
+        XCTAssertNil(WMSTileOverlay.validate(pngData, httpResponse(503)))
+    }
+
+    func testHtmlErrorPageWith200IsRejected() {
+        let html = Data("<html><body>Service unavailable</body></html>".utf8)
+        XCTAssertNil(WMSTileOverlay.validate(html, httpResponse(200)))
+    }
+
+    func testEmptyBodyIsRejected() {
+        XCTAssertNil(WMSTileOverlay.validate(Data(), httpResponse(200)))
+    }
+
+    func testNilDataIsRejected() {
+        XCTAssertNil(WMSTileOverlay.validate(nil, httpResponse(200)))
+    }
+
+    func testBodyShorterThanSignatureIsRejected() {
+        XCTAssertNil(WMSTileOverlay.validate(Data([0x89, 0x50, 0x4E]), httpResponse(200)))
+    }
+
+    func testNonHttpResponseIsRejected() {
+        let response = URLResponse(url: url, mimeType: "image/png", expectedContentLength: 10, textEncodingName: nil)
+        XCTAssertNil(WMSTileOverlay.validate(pngData, response))
+    }
+}


### PR DESCRIPTION
- Add WMSTileOverlay.validate() to check HTTP 2xx status and PNG signature
- Only cache tiles that pass validation; reject 429s and error pages
- Evict poisoned cache entries to prevent stale data across launches
- Bump URLCache directory to RadarTilesV2 to clear legacy bad entries
- Add regionDidChangeAnimated to trigger renderer.reloadData() for recovery
- Add scheduleInitialOverlayRefresh() for first-frame recovery after prefetch
- Add WMSTileOverlayTests.swift unit tests
- Add [Radar] rejected tile logging for debugging